### PR TITLE
Fix Hit Rate Revert Estimation

### DIFF
--- a/hitrate.js
+++ b/hitrate.js
@@ -66,12 +66,13 @@ function doSomeMath() {
   
     if (document.getElementById("physical").checked) {
       acc100 = (monAvoid * (55 + 2 * diff)) / 15;
-      accTarget = acc100 * (targetRatePercent / 100);
-  
-      const neededStat = accTarget * 0.5 + 1;
+
       const actualRate = 100 * ((charMain - acc100 * 0.5) / (acc100 * 0.5));
       const finalRate = Math.max(0, Math.min(100, actualRate));
-  
+
+      accTarget = acc100 * 0.5 * (1 + (targetRatePercent / 100));
+      const neededStat = Math.max(acc100 * 0.5 + 1, Math.min(acc100, accTarget));
+
       document.getElementById("mob1acc").value = neededStat.toFixed(2);
       document.getElementById("mob100acc").value = acc100.toFixed(2);
       const rateDisplay = document.getElementById("mobRate");
@@ -82,14 +83,16 @@ function doSomeMath() {
   
     const curAcc = Math.floor((charMain + charLuk) * 0.1);
     acc100 = (monAvoid + 1) * (1 + 0.04 * diff);
-    accTarget = acc100 * (targetRatePercent / 100);
   
     const acc1 = 0.41 * acc100;
     const accPart = Math.min(Math.max((curAcc - acc1 + 1) / (acc100 - acc1 + 1), 0), 1);
     const actualRate = (-0.7011618132 * Math.pow(accPart, 2) + 1.702139835 * accPart) * 100;
     const finalRate = Math.max(0, Math.min(100, actualRate));
-  
-    document.getElementById("mob1acc").value = accTarget.toFixed(2);
+
+    accTarget = (1.702139835 - Math.sqrt(2.89728001789 - 2.8046472528 * (targetRatePercent / 100))) / 1.4023236264;
+    const neededStat = Math.max(acc1, Math.min(acc100, accTarget * (acc100 - acc1 + 1) + acc1 - 1));
+
+    document.getElementById("mob1acc").value = neededStat.toFixed(2);
     document.getElementById("mob100acc").value = acc100.toFixed(2);
     const rateDisplay = document.getElementById("mobRate");
     rateDisplay.innerText = finalRate.toFixed(2) + "%";


### PR DESCRIPTION
百命的計算沒問題，但自訂命中率門段的相關實作是錯誤的

以物理職業來說，要能夠「摸到」怪物，門檻是「百分之百命中」的一半
舉例來說，無等差幼魔精靈需要 99 點命中才能完全不 Miss
這表示命中值需要 50 點才「有機會打中」，而要達成「命中機率過半」，則需要 75 點命中

目前該工具針對無等差幼魔精靈 50% 命中率給出的命中需求值為 25.75
但實際上這樣的命中值連摸到它的門檻都達不到

回頭看程式碼細節，targetRatePercent 直接乘上 acc100 是沒有意義的

```javascript
      acc100 = (monAvoid * (55 + 2 * diff)) / 15;
      accTarget = acc100 * (targetRatePercent / 100);  
      const neededStat = accTarget * 0.5 + 1;
```

正確的估算方式，應為

```javascript
      acc100 = (monAvoid * (55 + 2 * diff)) / 15;
      accTarget = acc100 * 0.5 * (1 + (targetRatePercent / 100));
      const neededStat = Math.max(acc100 * 0.5 + 1, Math.min(acc100, accTarget));
```

法系的部分，因為是曲線 $y=-0.7011618132x^2+1.702139835x$，回推得到

$$x=\frac{-1.702139835+\sqrt{1.702139835^2-4\times 0.7011618132\times y}}{(2\times -0.7011618132)}$$

簡化為

$$x=\frac{1.702139835-\sqrt{2.89728001789-2.8046472528\times y}}{1.4023236264}$$

```javascript
    acc100 = (monAvoid + 1) * (1 + 0.04 * diff);
    const acc1 = 0.41 * acc100;
    accTarget = (1.702139835 - Math.sqrt(2.89728001789 - 2.8046472528 * (targetRatePercent / 100))) / 1.4023236264;
    const neededStat = Math.max(acc1, Math.min(acc100, accTarget * (acc100 - acc1 + 1) + acc1 - 1));
```
